### PR TITLE
feat: tr-search-service의 QueryParser에 OR(|), NOT(-) 연산자 지원 및 테스트 코드 추…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:elasticsearch'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/trevari/spring/trsearchservice/application/QueryParser.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/application/QueryParser.java
@@ -1,0 +1,209 @@
+package com.trevari.spring.trsearchservice.application;
+
+import com.trevari.spring.trsearchservice.domain.search.ParsedQuery;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class QueryParser {
+    private static final String OR_DELIM = "\\|";
+    private static final String SPACE_DELIM = "\\s+";
+
+    private final int maxKeywords;
+
+    /**
+     * 기본 정책: 키워드 최대 2개
+     */
+    public QueryParser() {
+        this(2);
+    }
+
+    /**
+     * @param maxKeywords 키워드 총합(must + OR 평탄화 + mustNot)의 최대 허용 개수
+     */
+    public QueryParser(int maxKeywords) {
+        if (maxKeywords < 1) throw new IllegalArgumentException("maxKeywords must be >= 1");
+        this.maxKeywords = maxKeywords;
+    }
+
+    /**
+     * 주어진 raw 문자열을 파싱해 ParsedQuery를 생성한다.
+     * null/blank 입력은 모두 빈 쿼리로 간주한다.
+     */
+    public ParsedQuery parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return emptyQuery();
+        }
+
+        // 정규화: trim + lower
+        String normalized = normalize(raw);
+
+        // 누적용(입력 순서 유지)
+        LinkedHashSet<String> must = new LinkedHashSet<>();
+        LinkedHashSet<String> mustNot = new LinkedHashSet<>();
+        List<Set<String>> shouldGroups = new ArrayList<>();
+
+        for (String token : normalized.split(SPACE_DELIM)) {
+            if (token.isBlank()) continue;
+
+            if (isNotToken(token)) {
+                // NOT: 첫 글자 '-' 제거 후 정제
+                addIfPresent(mustNot, token.substring(1));
+            } else if (isOrGroup(token)) {
+                // OR 그룹: '|'로 나눠 정제/중복제거 후 그룹으로 저장
+                Set<String> group = splitOrGroup(token);
+                if (!group.isEmpty()) {
+                    shouldGroups.add(group);
+                }
+            } else {
+                // 일반 토큰
+                addIfPresent(must, token);
+            }
+        }
+
+        // 키워드 개수 제한 적용(정책)
+        enforceMaxKeywords(must, shouldGroups, mustNot, maxKeywords);
+
+        // 외부 변경 불가하도록 불변 래핑 후 VO 생성
+        return new ParsedQuery(
+                Collections.unmodifiableSet(must),
+                shouldGroups.stream()
+                        .map(set -> Collections.unmodifiableSet(new LinkedHashSet<>(set)))
+                        .collect(Collectors.toUnmodifiableList()),
+                Collections.unmodifiableSet(mustNot)
+        );
+    }
+
+    /* =========================
+       내부 유틸/헬퍼
+       ========================= */
+
+    private static String normalize(String s) {
+        return s.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isNotToken(String token) {
+        return token.startsWith("-") && token.length() > 1;
+    }
+
+    private static boolean isOrGroup(String token) {
+        return token.contains("|");
+    }
+
+    private static void addIfPresent(Set<String> target, String token) {
+        String t = token.trim();
+        // 단독 하이픈(예: "-")은 무시
+        if (t.isBlank() || "-".equals(t)) {
+            return;
+        }
+        target.add(t);
+    }
+
+    /**
+     * OR 그룹을 분해해 공백/빈문자 제거, 중복 제거(입력 순서 유지).
+     * 예) "tdd|javascript" -> ["tdd","javascript"]
+     */
+    private static Set<String> splitOrGroup(String token) {
+        return Arrays.stream(token.split(OR_DELIM))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static ParsedQuery emptyQuery() {
+        return new ParsedQuery(Set.of(), List.of(), Set.of());
+    }
+
+    /**
+     * must + OR 그룹 평탄화 + mustNot의 총합이 maxKeywords를 초과하면
+     * 초과분을 잘라낸다(정책). 필요 시 예외로 바꿀 수 있음.
+     */
+    private static void enforceMaxKeywords(Set<String> must,
+                                           List<Set<String>> shouldGroups,
+                                           Set<String> mustNot,
+                                           int maxKeywords) {
+        int remaining = maxKeywords;
+
+        // 1) MUST에서 remaining만큼만 남김
+        trimSetInPlace(must, remaining);
+        remaining -= must.size();
+        if (remaining <= 0) {
+            shouldGroups.clear();
+            mustNot.clear();
+            return;
+        }
+
+        // 2) SHOULD 그룹(평탄화 기준)에서 remaining만큼만 남김
+        int keptFromShould = trimShouldGroupsInPlace(shouldGroups, remaining);
+        remaining -= keptFromShould;
+        if (remaining <= 0) {
+            mustNot.clear();
+            return;
+        }
+
+        // 3) MUST_NOT에서 remaining만큼만 남김
+        trimSetInPlace(mustNot, remaining);
+    }
+
+    /**
+     * Set을 앞에서부터 remaining 개수만 남기고 잘라낸다.
+     */
+    private static void trimSetInPlace(Set<String> set, int remaining) {
+        if (remaining <= 0) {
+            set.clear();
+            return;
+        }
+        if (set.size() <= remaining) return;
+
+        Iterator<String> it = set.iterator();
+        int kept = 0;
+        LinkedHashSet<String> trimmed = new LinkedHashSet<>();
+        while (it.hasNext() && kept < remaining) {
+            trimmed.add(it.next());
+            kept++;
+        }
+        set.clear();
+        set.addAll(trimmed);
+    }
+
+    /**
+     * OR 그룹 전체를 평탄화 기준으로 remaining만큼만 남기고 이후는 그룹에서 제거.
+     * @return 실제 남은 total count (OR 평탄화 기준)
+     */
+    private static int trimShouldGroupsInPlace(List<Set<String>> groups, int remaining) {
+        if (remaining <= 0) {
+            groups.clear();
+            return 0;
+        }
+        int keptTotal = 0;
+        ListIterator<Set<String>> it = groups.listIterator();
+        while (it.hasNext()) {
+            Set<String> group = it.next();
+            if (group.isEmpty()) {
+                it.remove();
+                continue;
+            }
+            if (keptTotal >= remaining) {
+                it.remove();
+                continue;
+            }
+            int canKeep = remaining - keptTotal;
+            if (group.size() > canKeep) {
+                // 그룹에서 앞의 canKeep만 유지
+                LinkedHashSet<String> trimmed = new LinkedHashSet<>();
+                int i = 0;
+                for (String s : group) {
+                    if (i++ >= canKeep) break;
+                    trimmed.add(s);
+                }
+                it.set(trimmed);
+                keptTotal += trimmed.size();
+            } else {
+                keptTotal += group.size();
+            }
+        }
+        return keptTotal;
+    }
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/config/OpenApiConfig.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.trevari.spring.trsearchservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI catalogOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Trevari Search API")
+                        .description("도서 검색 API 문서")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/domain/search/ParsedQuery.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/domain/search/ParsedQuery.java
@@ -1,0 +1,11 @@
+package com.trevari.spring.trsearchservice.domain.search;
+
+import java.util.List;
+import java.util.Set;
+
+public record ParsedQuery(
+        Set<String> must,
+        List<Set<String>> shouldGroups,
+        Set<String> mustNot
+) {
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/domain/search/SearchService.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/domain/search/SearchService.java
@@ -1,0 +1,7 @@
+package com.trevari.spring.trsearchservice.domain.search;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class SearchService {
+}

--- a/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserNotEdgeTest.java
+++ b/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserNotEdgeTest.java
@@ -1,0 +1,43 @@
+package com.trevari.spring.trsearchservice.application;
+
+import com.trevari.spring.trsearchservice.domain.search.ParsedQuery;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryParserNotEdgeTest {
+    private final QueryParser parser = new QueryParser(2);
+
+    @Test
+    void 하이픈만_있는_토큰은_무시_테스트() {
+        // given, when
+        ParsedQuery q = parser.parse("-  -   -  ");
+
+        // then
+        assertThat(q.mustNot()).isEmpty();
+        assertThat(q.must()).isEmpty();
+        assertThat(q.shouldGroups()).isEmpty();
+    }
+
+    @Test
+    void 단독_하이픈은_무시되고_정상_토큰만_남는다_테스트() {
+        // given, when
+        ParsedQuery q = parser.parse("-  java  -  tdd  -");
+
+        // then
+        assertThat(q.must()).containsExactly("java", "tdd");
+        assertThat(q.mustNot()).isEmpty();
+        assertThat(q.shouldGroups()).isEmpty();
+    }
+
+    @Test
+    void NOT_여러개_테스트() {
+        // given, when
+        ParsedQuery q = parser.parse("-java -python -go");
+
+        // then
+        // case1) maxKeywords=2가 "must만 제한"이면 그대로 유지
+        // case2) maxKeywords=2가 "전체 합산 제한"이면 go는 무시됨
+        assertThat(q.mustNot()).containsExactly("java", "python");
+    }
+}

--- a/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserOrEdgeTest.java
+++ b/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserOrEdgeTest.java
@@ -1,0 +1,39 @@
+package com.trevari.spring.trsearchservice.application;
+
+import com.trevari.spring.trsearchservice.domain.search.ParsedQuery;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryParserOrEdgeTest {
+
+    private final QueryParser parser = new QueryParser(5);
+
+    @Test
+    void 빈_OR_토큰_무시_테스트() {
+        // given
+        ParsedQuery q = parser.parse("||tdd||");
+
+        // when
+        // 공백/빈문자 제거되므로 "tdd" 만 남음
+        int total = q.must().size()
+                + (int) q.shouldGroups().stream().flatMap(java.util.Collection::stream).count()
+                + q.mustNot().size();
+
+        // then
+        assertThat(total).isEqualTo(1);
+        assertThat(q.shouldGroups()).hasSize(1);
+        assertThat(q.shouldGroups().get(0)).containsExactly("tdd");
+    }
+
+    @Test
+    void OR_여러_그룹_테스트() {
+        // given, when
+        ParsedQuery q = parser.parse("a|b c|d");
+
+        // then
+        assertThat(q.shouldGroups()).hasSize(2);
+        assertThat(q.shouldGroups().get(0)).containsExactly("a", "b");
+        assertThat(q.shouldGroups().get(1)).containsExactly("c", "d");
+    }
+}

--- a/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserPolicyTest.java
+++ b/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserPolicyTest.java
@@ -1,0 +1,41 @@
+package com.trevari.spring.trsearchservice.application;
+
+import com.trevari.spring.trsearchservice.domain.search.ParsedQuery;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class QueryParserPolicyTest {
+
+    @Test
+    void 최대_키워드_2개_정책_적용_테스트() {
+        // given
+        QueryParser parser = new QueryParser(2);
+        ParsedQuery q = parser.parse("tdd|java spring -legacy");
+
+        // when
+        // 평탄화 기준 총 입력 키워드: "tdd","java","spring","legacy" (4개)
+        // 2개만 남겨야 함(앞에서부터 남기기): OR 그룹에서 1개만 남고, mustNot은 잘릴 수 있음
+        int total =
+                q.must().size()
+                        + (int) q.shouldGroups().stream().flatMap(java.util.Collection::stream).count()
+                        + q.mustNot().size();
+
+        // then
+        assertThat(total).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void 최대_키워드_3개로_완화하면_OR_한_그룹_2개까지_허용될_수_있음_테스트() {
+        // given, when
+        QueryParser parser = new QueryParser(3);
+        ParsedQuery q = parser.parse("spring tdd|java -legacy");
+
+        // then
+        // 남는 전략: must("spring") 1 + OR("tdd","java") 2 = 3 → mustNot은 잘림
+        assertThat(q.must()).containsExactly("spring");
+        assertThat(q.shouldGroups()).hasSize(1);
+        assertThat(q.shouldGroups().get(0)).containsExactly("tdd", "java");
+        assertThat(q.mustNot()).isEmpty();
+    }
+}

--- a/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserTest.java
+++ b/src/test/java/com/trevari/spring/trsearchservice/application/QueryParserTest.java
@@ -1,0 +1,97 @@
+package com.trevari.spring.trsearchservice.application;
+
+import com.trevari.spring.trsearchservice.domain.search.ParsedQuery;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryParserTest {
+
+    private final QueryParser parser = new QueryParser(); // max 2 keywords 정책
+
+    @Test
+    void 빈_입력은_빈_쿼리_테스트() {
+        // given, when
+        ParsedQuery q1 = parser.parse(null);
+        ParsedQuery q2 = parser.parse("   ");
+
+        // then
+        assertThat(q1.must()).isEmpty();
+        assertThat(q1.mustNot()).isEmpty();
+        assertThat(q1.shouldGroups()).isEmpty();
+
+        assertThat(q2.must()).isEmpty();
+        assertThat(q2.mustNot()).isEmpty();
+        assertThat(q2.shouldGroups()).isEmpty();
+    }
+
+    @Test
+    void 일반_키워드_must_테스트() {
+        // given, when
+        ParsedQuery q = parser.parse("tdd");
+
+        // then
+        assertThat(q.must()).containsExactly("tdd");
+        assertThat(q.mustNot()).isEmpty();
+        assertThat(q.shouldGroups()).isEmpty();
+    }
+
+    @Test
+    void OR_연산자_shouldGroups_한_그룹() {
+        // given, when
+        ParsedQuery q = parser.parse("tdd|javascript");
+
+        // then
+        assertThat(q.must()).isEmpty();
+        assertThat(q.shouldGroups()).hasSize(1);
+        assertThat(q.shouldGroups().get(0)).containsExactly("tdd", "javascript");
+        assertThat(q.mustNot()).isEmpty();
+    }
+
+    @Test
+    void NOT_연산자_mustNot() {
+        // given, when
+        ParsedQuery q = parser.parse("-java");
+
+        // then
+        assertThat(q.must()).isEmpty();
+        assertThat(q.mustNot()).containsExactly("java");
+        assertThat(q.shouldGroups()).isEmpty();
+    }
+
+    @Test
+    void 혼합_케이스_must_OR_mustNot() {
+        // given, when
+        ParsedQuery q = parser.parse("spring tdd|clean -legacy");
+
+        // then
+        // 기본 정책(max=2)이 적용되므로 총 2개만 남음 (앞에서부터 보존)
+        // 입력 순서 기준: must("spring") 1개 + OR("tdd","clean")에서 1개만 남고, mustNot는 잘림
+        assertThat(q.must()).containsExactly("spring");
+        assertThat(q.shouldGroups()).hasSize(1);
+        assertThat(q.shouldGroups().get(0)).hasSize(1);
+        assertThat(q.mustNot()).isEmpty();
+    }
+
+    @Test
+    void 대소문자_정규화() {
+        // given, when
+        ParsedQuery q = parser.parse("   TDD   ");
+
+        // then
+        assertThat(q.must()).containsExactly("tdd");
+    }
+
+    @Test
+    void 공백과_중복_제거() {
+        // given, when
+        ParsedQuery q = parser.parse("tdd   tdd  |  tdd  ");
+
+        // then
+        // max=2 → 결국 총 2개만 유지, 중복 제거
+        // must: ["tdd"], shouldGroups: [["tdd"]] (또는 must에서만 1개일 수도)
+        assertThat(q.must()).contains("tdd");
+        assertThat(q.must()).hasSizeLessThanOrEqualTo(1);
+        assertThat(q.shouldGroups()).allSatisfy(g -> assertThat(g).hasSizeLessThanOrEqualTo(1));
+    }
+}


### PR DESCRIPTION
## 개요
- QueryParser에서 OR(|), NOT(-) 연산자를 지원하도록 기능 추가
- 관련 Issue: #3

## 변경 사항
- QueryParser에 OR, NOT 연산자 파싱 로직 구현
- 단위 테스트 코드 추가 (성공/실패 케이스 포함)