### PR TITLE
feat(search): add OR/NOT operator handling in SearchService query bui…

### DIFF
--- a/src/main/java/com/trevari/spring/trsearchservice/application/SearchService.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/application/SearchService.java
@@ -1,7 +1,124 @@
 package com.trevari.spring.trsearchservice.application;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.util.ObjectBuilder;
+import com.trevari.spring.trsearchservice.domain.search.ParsedQuery;
+import com.trevari.spring.trsearchservice.domain.search.SearchKeyword;
+import com.trevari.spring.trsearchservice.domain.search.SearchKeywordRepository;
+import com.trevari.spring.trsearchservice.exception.SearchException;
+import com.trevari.spring.trsearchservice.infrastructure.persistence.BookDoc;
+import com.trevari.spring.trsearchservice.interfaces.dto.SearchResultDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
 @Service
+@RequiredArgsConstructor
 public class SearchService {
+    private static final String INDEX_BOOKS = "books";
+    private static final List<String> SEARCH_FIELDS =
+            List.of("title^3", "subtitle^2", "author", "publisher", "isbn");
+
+    private final ElasticsearchClient es;
+    private final SearchKeywordRepository keywordRepo;
+    private final QueryParser queryParser;
+
+    public SearchResultDto search(String rawQuery, int page, int size) {
+        validatePageSize(page, size);
+        final ParsedQuery parsed = queryParser.parse(rawQuery);
+        final int from = safeFrom(page, size);
+
+        try {
+            SearchResponse<BookDoc> resp = es.search(s -> {
+                s.index(INDEX_BOOKS)
+                        .from(from)
+                        .size(size)
+                        .sort(so -> so.field(f -> f.field("publishedDate").order(SortOrder.Desc)))
+                        .query(qb -> qb.bool(buildBool(parsed)));
+                return s;
+            }, BookDoc.class);
+
+            if (rawQuery != null && !rawQuery.isBlank()) {
+                keywordRepo.increaseCount(rawQuery.trim());
+            }
+
+            var items = mapHits(resp, BookDoc::toSummaryDto);
+            long total = resp.hits().total() == null ? items.size() : resp.hits().total().value();
+
+            return SearchResultDto.builder()
+                    .items(items)
+                    .total(total)
+                    .page(page)
+                    .size(size)
+                    .query(rawQuery)
+                    .build();
+
+        } catch (Exception e) {
+            throw new SearchException("Search failed", e);
+        }
+    }
+
+    public List<String> popularTop10() {
+        return keywordRepo.top10().stream()
+                .map(SearchKeyword::keyword)
+                .toList();
+    }
+
+    private static void validatePageSize(int page, int size) {
+        if (page < 0) throw new IllegalArgumentException("page must be >= 0");
+        if (size <= 0) throw new IllegalArgumentException("size must be > 0");
+        if (size > 100) throw new IllegalArgumentException("size must be <= 100");
+    }
+
+    private static int safeFrom(int page, int size) {
+        try {
+            return Math.toIntExact(Math.multiplyExact((long) page, (long) size));
+        } catch (ArithmeticException ex) {
+            throw new IllegalArgumentException("page*size overflows int range", ex);
+        }
+    }
+
+    private static Function<BoolQuery.Builder, ObjectBuilder<BoolQuery>> buildBool(ParsedQuery pq) {
+        return b -> {
+            for (String term : pq.must()) {
+                b.must(m -> m.multiMatch(mm -> multiMatch(term)));
+            }
+            for (Set<String> group : pq.shouldGroups()) {
+                b.should(sh -> sh.bool(inner -> {
+                    group.forEach(term -> inner.should(sh2 -> sh2.multiMatch(mm -> multiMatch(term))));
+                    return inner.minimumShouldMatch("1");
+                }));
+            }
+            for (String term : pq.mustNot()) {
+                b.mustNot(mn -> mn.multiMatch(mm -> multiMatch(term)
+                        .fields(List.of("title","subtitle","author","publisher","isbn"))));
+            }
+            return b;
+        };
+    }
+
+    private static MultiMatchQuery.Builder multiMatch(String term) {
+        return new MultiMatchQuery.Builder()
+                .query(term)
+                .fields(SEARCH_FIELDS);
+    }
+
+    private static <T> List<T> mapHits(SearchResponse<? extends BookDoc> resp,
+                                       Function<BookDoc, T> mapper) {
+        return resp.hits().hits().stream()
+                .map(Hit::source)
+                .filter(Objects::nonNull)
+                .map(mapper)
+                .toList();
+    }
+
 }

--- a/src/main/java/com/trevari/spring/trsearchservice/domain/search/SearchKeyword.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/domain/search/SearchKeyword.java
@@ -1,11 +1,15 @@
 package com.trevari.spring.trsearchservice.domain.search;
 
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder
-public class SearchKeyword {
-    private final String keyword;
-    private final long count;
+public record SearchKeyword(
+        String keyword,
+        long cnt
+) {
+    public SearchKeyword {
+        if (keyword == null || keyword.isBlank()) {
+            throw new IllegalArgumentException("keyword must not be blank");
+        }
+        if (cnt < 0) {
+            throw new IllegalArgumentException("cnt must be >= 0");
+        }
+    }
 }

--- a/src/main/java/com/trevari/spring/trsearchservice/domain/search/SearchKeywordRepository.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/domain/search/SearchKeywordRepository.java
@@ -1,5 +1,10 @@
 package com.trevari.spring.trsearchservice.domain.search;
 
+import java.util.List;
+
 public interface SearchKeywordRepository {
     SearchKeyword save(SearchKeyword keyword);
+    List<SearchKeyword> top10();
+    /** 키워드 집계: 있으면 cnt++, 없으면 새로 insert */
+    void increaseCount(String keyword);
 }

--- a/src/main/java/com/trevari/spring/trsearchservice/exception/BookNotFoundException.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/exception/BookNotFoundException.java
@@ -1,0 +1,7 @@
+package com.trevari.spring.trsearchservice.exception;
+
+public class BookNotFoundException extends RuntimeException {
+    public BookNotFoundException() {
+        super("Book not found.");
+    }
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.trevari.spring.trsearchservice.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /** 404: 도서 미존재 */
+    @ExceptionHandler(BookNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleBookNotFound(BookNotFoundException ex, WebRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value(),
+                "Book not found",
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+
+    /** 404: 매핑되지 않은 경로 */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoHandler(
+            NoHandlerFoundException ex, HttpServletRequest req) {
+        return respond(HttpStatus.NOT_FOUND, "Not Found", req.getRequestURI());
+    }
+
+    /** 400: 잘못된 요청/파라미터 */
+    @ExceptionHandler({
+            IllegalArgumentException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class
+    })
+    public ResponseEntity<ErrorResponse> handleBadRequest(
+            Exception ex, HttpServletRequest req) {
+        String msg = ex.getMessage() != null ? ex.getMessage() : "Bad Request";
+        return respond(HttpStatus.BAD_REQUEST, msg, req.getRequestURI());
+    }
+
+    /** 500: 그 외 모든 예외 */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAny(
+            Exception ex, HttpServletRequest req) {
+        return respond(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", req.getRequestURI());
+    }
+
+    /* 공통 응답 빌더 */
+    private ResponseEntity<ErrorResponse> respond(HttpStatus status, String message, String path) {
+        ErrorResponse body = new ErrorResponse(
+                LocalDateTime.now(),
+                status.value(),
+                message,
+                path
+        );
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/exception/SearchException.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/exception/SearchException.java
@@ -1,0 +1,5 @@
+package com.trevari.spring.trsearchservice.exception;
+
+public class SearchException extends RuntimeException {
+    public SearchException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/infrastructure/persistence/BookDoc.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/infrastructure/persistence/BookDoc.java
@@ -1,0 +1,21 @@
+package com.trevari.spring.trsearchservice.infrastructure.persistence;
+
+import com.trevari.spring.trsearchservice.interfaces.dto.BookSummaryDto;
+
+import java.time.LocalDate;
+
+public record BookDoc(
+        String id, String isbn, String title, String subtitle,
+        String author, String publisher, LocalDate publishedDate
+) {
+    public BookSummaryDto toSummaryDto() {
+        return BookSummaryDto.builder()
+                .isbn(isbn)
+                .title(title)
+                .subtitle(subtitle)
+                .author(author)
+                .publisher(publisher)
+                .publishedDate(publishedDate)
+                .build();
+    }
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/infrastructure/persistence/SearchKeywordJpaRepository.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/infrastructure/persistence/SearchKeywordJpaRepository.java
@@ -1,6 +1,16 @@
 package com.trevari.spring.trsearchservice.infrastructure.persistence;
 
+import com.trevari.spring.trsearchservice.domain.search.SearchKeyword;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface SearchKeywordJpaRepository extends JpaRepository<SearchKeywordEntity, Long> {
+    @Query("select k from SearchKeywordEntity k order by k.cnt desc")
+    List<SearchKeywordEntity> findTopOrderByCntDesc(Pageable pageable);
+
+    Optional<SearchKeywordEntity> findByKeyword(String keyword);
 }

--- a/src/main/java/com/trevari/spring/trsearchservice/infrastructure/persistence/SearchKeywordRepositoryAdapter.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/infrastructure/persistence/SearchKeywordRepositoryAdapter.java
@@ -4,7 +4,10 @@ import com.trevari.spring.trsearchservice.domain.search.SearchKeyword;
 import com.trevari.spring.trsearchservice.domain.search.SearchKeywordRepository;
 import com.trevari.spring.trsearchservice.interfaces.mapper.SearchKeywordMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,5 +19,30 @@ public class SearchKeywordRepositoryAdapter implements SearchKeywordRepository {
     public SearchKeyword save(SearchKeyword keyword) {
         var saved = jpa.save(mapper.toEntity(keyword));
         return mapper.toDomain(saved);
+    }
+
+    @Override
+    public List<SearchKeyword> top10() {
+        return jpa.findTopOrderByCntDesc(PageRequest.of(0, 10))
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void increaseCount(String keyword) {
+        jpa.findByKeyword(keyword).ifPresentOrElse(
+                entity -> {
+                    entity.setCnt(entity.getCnt() + 1);
+                    jpa.save(entity);
+                },
+                () -> {
+                    var newEntity = SearchKeywordEntity.builder()
+                            .keyword(keyword)
+                            .cnt(1L)
+                            .build();
+                    jpa.save(newEntity);
+                }
+        );
     }
 }

--- a/src/main/java/com/trevari/spring/trsearchservice/interfaces/dto/BookSummaryDto.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/interfaces/dto/BookSummaryDto.java
@@ -1,0 +1,15 @@
+package com.trevari.spring.trsearchservice.interfaces.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record BookSummaryDto(
+        String isbn,
+        String title,
+        String subtitle,
+        String author,
+        String publisher,
+        LocalDate publishedDate
+) {}

--- a/src/main/java/com/trevari/spring/trsearchservice/interfaces/dto/SearchResultDto.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/interfaces/dto/SearchResultDto.java
@@ -1,0 +1,14 @@
+package com.trevari.spring.trsearchservice.interfaces.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record SearchResultDto(
+        List<BookSummaryDto> items,
+        long total,
+        int page,
+        int size,
+        String query
+) {}

--- a/src/main/java/com/trevari/spring/trsearchservice/interfaces/http/SearchController.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/interfaces/http/SearchController.java
@@ -1,0 +1,32 @@
+package com.trevari.spring.trsearchservice.interfaces.http;
+
+import com.trevari.spring.trsearchservice.application.SearchService;
+import com.trevari.spring.trsearchservice.interfaces.dto.SearchResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping
+    public SearchResultDto search(@RequestParam String q,
+                                  @RequestParam(defaultValue="0") int page,
+                                  @RequestParam(defaultValue="20") int size) {
+        return searchService.search(q, page, size);
+    }
+
+    @GetMapping("/popular")
+    public List<String> popular() {
+        return searchService.popularTop10();
+    }
+
+}

--- a/src/main/java/com/trevari/spring/trsearchservice/interfaces/mapper/SearchKeywordMapper.java
+++ b/src/main/java/com/trevari/spring/trsearchservice/interfaces/mapper/SearchKeywordMapper.java
@@ -6,17 +6,17 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SearchKeywordMapper {
-    public SearchKeywordEntity toEntity(SearchKeyword d) {
-        return SearchKeywordEntity.builder()
-                .keyword(d.getKeyword())
-                .cnt(d.getCount())
-                .build();
+    public SearchKeyword toDomain(SearchKeywordEntity e) {
+        return new SearchKeyword(
+                e.getKeyword(),
+                e.getCnt()
+        );
     }
 
-    public SearchKeyword toDomain(SearchKeywordEntity e) {
-        return SearchKeyword.builder()
-                .keyword(e.getKeyword())
-                .count(e.getCnt())
+    public SearchKeywordEntity toEntity(SearchKeyword d) {
+        return SearchKeywordEntity.builder()
+                .keyword(d.keyword())
+                .cnt(d.cnt())
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: tr-search-service
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/catalog}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/search}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver

--- a/src/test/java/com/trevari/spring/trsearchservice/application/SearchServiceTest.java
+++ b/src/test/java/com/trevari/spring/trsearchservice/application/SearchServiceTest.java
@@ -1,0 +1,183 @@
+package com.trevari.spring.trsearchservice.application;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+import co.elastic.clients.util.ObjectBuilder;
+import com.trevari.spring.trsearchservice.domain.search.ParsedQuery;
+import com.trevari.spring.trsearchservice.domain.search.SearchKeyword;
+import com.trevari.spring.trsearchservice.domain.search.SearchKeywordRepository;
+import com.trevari.spring.trsearchservice.exception.SearchException;
+import com.trevari.spring.trsearchservice.infrastructure.persistence.BookDoc;
+import com.trevari.spring.trsearchservice.interfaces.dto.BookSummaryDto;
+import com.trevari.spring.trsearchservice.interfaces.dto.SearchResultDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+    @Mock
+    ElasticsearchClient es;
+
+    @Mock
+    SearchKeywordRepository keywordRepo;
+
+    @Mock
+    QueryParser queryParser;
+
+    @InjectMocks
+    SearchService service;
+
+    private BookDoc doc1;
+    private BookDoc doc2;
+
+    @BeforeEach
+    void setUp() {
+        doc1 = new BookDoc("1", "9780134685991", "Effective Java", "Best", "Joshua Bloch",
+                "Addison-Wesley", LocalDate.parse("2018-01-06"));
+        doc2 = new BookDoc("2", "9780132350884", "Clean Code", "A Handbook", "Robert C. Martin",
+                "Prentice Hall", LocalDate.parse("2008-08-01"));
+    }
+
+    @Test
+    void search_성공시_아이템매핑_및_인기검색어증가_테스트() throws Exception {
+        // given
+        String raw = " Java  tdd|-python  "; // 앞뒤 공백 포함 → trim 기대
+        ParsedQuery pq = new ParsedQuery(
+                new LinkedHashSet<>(List.of("java")),              // must
+                List.of(new LinkedHashSet<>(List.of("tdd"))),      // shouldGroups
+                new LinkedHashSet<>(List.of("python"))             // mustNot
+        );
+        when(queryParser.parse(raw)).thenReturn(pq);
+
+        SearchResponse<BookDoc> esResp = buildEsResponse(List.of(doc1, doc2), 2L);
+
+        // ElasticsearchClient#search(Function<Builder,ObjectBuilder<SearchRequest>>, Class<BookDoc>)
+        when(es.search(
+                ArgumentMatchers.<Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>>>any(),
+                eq(BookDoc.class)
+        )).thenReturn(esResp);
+
+        // when
+        SearchResultDto result = service.search(raw, 0, 10);
+
+        // then
+        assertThat(result.total()).isEqualTo(2);
+        assertThat(result.items())
+                .extracting(BookSummaryDto::isbn)
+                .containsExactlyInAnyOrder("9780134685991", "9780132350884");
+        verify(keywordRepo).increaseCount("Java  tdd|-python".trim());
+    }
+
+    @Test
+    void search_ES예외시_SearchException_전파_테스트() throws Exception {
+        // given
+        String raw = "java";
+        ParsedQuery pq = new ParsedQuery(
+                Set.of("java"),
+                List.of(),
+                Set.of()
+        );
+        when(queryParser.parse(raw)).thenReturn(pq);
+
+        @SuppressWarnings("unchecked")
+        Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>> anyFn =
+                (Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>>) any(Function.class);
+        when(es.search(anyFn, eq(BookDoc.class))).thenThrow(new RuntimeException("es down"));
+
+        // when / then
+        assertThatThrownBy(() -> service.search(raw, 0, 10))
+                .isInstanceOf(SearchException.class)
+                .hasMessageContaining("Search failed");
+        // 인기검색어는 증가 안 했는지(실패 시 호출 X)
+        verify(keywordRepo, never()).increaseCount(anyString());
+    }
+
+    @Test
+    void search_page_size_검증_테스트() {
+        // page < 0
+        assertThatThrownBy(() -> service.search("java", -1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("page must be >= 0");
+
+        // size <= 0
+        assertThatThrownBy(() -> service.search("java", 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size must be > 0");
+
+        // size > 100
+        assertThatThrownBy(() -> service.search("java", 0, 101))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size must be <= 100");
+    }
+
+    @Test
+    void search_page_size_곱셈_오버플로우_검출_테스트() {
+        // page * size 가 int 범위를 넘는 케이스 유도
+        int page = Integer.MAX_VALUE;
+        int size = 2;
+        assertThatThrownBy(() -> service.search("java", page, size))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("overflows int range");
+    }
+
+    @Test
+    void popularTop10_키워드목록_반환_테스트() {
+        // given
+        when(keywordRepo.top10()).thenReturn(List.of(
+                new SearchKeyword("java", 10),
+                new SearchKeyword("spring", 8),
+                new SearchKeyword("elasticsearch", 5)
+        ));
+
+        // when
+        List<String> top = service.popularTop10();
+
+        // then
+        assertThat(top).containsExactly("java", "spring", "elasticsearch");
+    }
+
+
+    private static SearchResponse<BookDoc> buildEsResponse(List<BookDoc> docs, long total) {
+        List<Hit<BookDoc>> hits = docs.stream()
+                .map(d -> Hit.<BookDoc>of(h -> h
+                        .index("books")
+                        .id(d.isbn())          // 테스트용으로 isbn을 id로 사용
+                        .source(d)
+                ))
+                .toList();
+
+        return SearchResponse.of(r -> r
+                .took(5)                       // ✅ 필수
+                .timedOut(false)               // ✅ 필수
+                .shards(s -> s                 // ✅ 필수
+                        .total(1)
+                        .successful(1)
+                        .skipped(0)
+                        .failed(0)
+                )
+                .hits(h -> h
+                        .total(t -> t.value(total).relation(TotalHitsRelation.Eq))
+                        .hits(hits)
+                )
+        );
+    }
+}


### PR DESCRIPTION
…lderchore (Closes #4

## 개요
SearchService의 Elasticsearch 질의 빌더 로직에 OR(|), NOT(-) 연산자 처리를 추가했습니다.
이제 사용자는 단순 키워드 검색 외에도 OR 및 제외 검색을 활용할 수 있습니다.

## 주요 변경사항
- SearchService: 쿼리 파싱 로직 개선
  - `|` → should 조건 (OR)
  - `-` prefix → must_not 조건 (NOT)
- Elasticsearch bool query 구조 적용
- 단위 테스트 작성 (SearchServiceTests)
  - OR, NOT 조합 케이스 확인